### PR TITLE
feat: implement the empty operation

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -15,3 +15,4 @@ export function sha256Hex(data: string | Uint8Array): string {
 }
 export { default as parseXML } from "https://raw.githubusercontent.com/nekobato/deno-xml-parser/0bc4c2bd2f5fad36d274279978ca57eec57c680c/index.ts";
 export { decode as decodeXMLEntities } from "https://deno.land/x/html_entities@v1.0/lib/xml-entities.js";
+export { pooledMap } from "https://deno.land/std@0.71.0/async/pool.ts";

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -33,8 +33,6 @@ export interface S3BucketConfig extends S3Config {
   bucket: string;
 }
 
-export type DeletedKeys = string[];
-
 export class S3Bucket {
   #signer: Signer;
   #host: string;
@@ -489,8 +487,11 @@ export class S3Bucket {
     };
   }
 
-  async empty(): Promise<DeletedKeys> {
-    const deleted: DeletedKeys = [];
+  /**
+   * Deletes all objects in the bucket recursively. Returns a list of deleted keys.
+   */
+  async empty(): Promise<string[]> {
+    const deleted: string[] = [];
     let ls: ListObjectsResponse | undefined;
     do {
       ls = await this.listObjects({
@@ -504,9 +505,9 @@ export class S3Bucket {
     return deleted;
   }
 
-  private async deleteMany(objects: S3Object[]): Promise<DeletedKeys> {
+  private async deleteMany(objects: S3Object[]): Promise<string[]> {
     const p: Promise<DeleteObjectResponse>[] = [];
-    const deleted: DeletedKeys = [];
+    const deleted: string[] = [];
     objects.forEach((o) => {
       if (o.key) {
         p.push(

--- a/src/bucket_test.ts
+++ b/src/bucket_test.ts
@@ -221,3 +221,33 @@ Deno.test({
     }
   },
 });
+
+Deno.test({
+  name: "empty bucket",
+  ignore: true,
+  async fn() {
+    // setup
+    const content = encoder.encode("Test1");
+    const keys = [
+      "fooz",
+      "bar",
+      "foo/sub2",
+      "foo/sub3/subsub",
+      "baz",
+      "fruits/blueberry",
+      "fruits/banana",
+      "fruits/strawberry",
+      "fruits/apple",
+      "fruits/orange",
+    ];
+
+    for (let k of keys) {
+      await bucket.putObject(k, content, { contentType: "text/plain" });
+    }
+
+    const deleted = await bucket.empty();
+    deleted.sort();
+    keys.sort();
+    assertEquals(deleted, keys);
+  },
+});

--- a/src/bucket_test.ts
+++ b/src/bucket_test.ts
@@ -224,7 +224,6 @@ Deno.test({
 
 Deno.test({
   name: "empty bucket",
-  ignore: true,
   async fn() {
     // setup
     const content = encoder.encode("Test1");


### PR DESCRIPTION
This will implement the `empty` action available in the console(`rm --recursive` in the cli). I want the behavior to be drawn from the behavior of the cli; the function will return a list of keys that were deleted. I'm also thinking about adding a `quiet` option that simply returns the keys that failed to delete, but probably not for the first version.