### PR TITLE
Include x-amz-content-sha256 in signedHeaders

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -36,10 +36,10 @@ export async function doRequest({
     method,
     body,
   });
-
-  const signedRequest = await signer.sign("s3", request);
+  
   const contentHash = await sha256Hex(body ?? "");
-  signedRequest.headers.set("x-amz-content-sha256", contentHash);
+  request.headers.set("x-amz-content-sha256", contentHash);
+  const signedRequest = await signer.sign("s3", request);
   if (body) {
     signedRequest.headers.set("content-length", body.length.toFixed(0));
   }

--- a/src/request.ts
+++ b/src/request.ts
@@ -36,7 +36,7 @@ export async function doRequest({
     method,
     body,
   });
-  
+
   const contentHash = await sha256Hex(body ?? "");
   request.headers.set("x-amz-content-sha256", contentHash);
   const signedRequest = await signer.sign("s3", request);


### PR DESCRIPTION
I received:

```
<Error>
    <Code>InvalidRequest</Code>
    <Message>header 'x-amz-content-sha256' must be included in signature</Message>
</Error>
```

The PR fixes that.