### PR TITLE
chore: use GitHub warning message on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Amazon S3 for Deno
 
-> ⚠️ This project is work in progress. Expect breaking changes.
+> **Warning** This project is work in progress. Expect breaking changes.
 
 ## Example
 


### PR DESCRIPTION
A small change.

Before:
![Screenshot_20220709_140133](https://user-images.githubusercontent.com/84047886/178119442-488f1861-c716-4bb2-854a-4a210cc415b5.png)

After:
![image](https://user-images.githubusercontent.com/84047886/178119466-8395c5bc-f4a6-484f-8b38-afd10e2c68eb.png)