### PR TITLE
fix(signer): Strictly follow qp canonicalization spec

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -2,11 +2,12 @@ export {
   AWSSignerV4,
   toAmz,
   toDateStamp,
-} from "https://deno.land/x/aws_sign_v4@1.0.2/mod.ts";
+  encodeUriS3,
+} from "https://cdn.jsdelivr.net/gh/lionel-rowe/deno_aws_sign_v4@1.0.2-fork.2/mod.ts";
 export type {
   Credentials,
   Signer,
-} from "https://deno.land/x/aws_sign_v4@1.0.2/mod.ts";
+} from "https://cdn.jsdelivr.net/gh/lionel-rowe/deno_aws_sign_v4@1.0.2-fork.2/mod.ts";
 export { default as parseXML } from "https://raw.githubusercontent.com/nekobato/deno-xml-parser/0bc4c2bd2f5fad36d274279978ca57eec57c680c/index.ts";
 export { decode as decodeXMLEntities } from "https://deno.land/x/html_entities@v1.0/lib/xml-entities.js";
 export { pooledMap } from "https://deno.land/std@0.115.1/async/pool.ts";

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -1,12 +1,12 @@
 import {
   AWSSignerV4,
   decodeXMLEntities,
+  encodeUriS3,
   parseXML,
   pooledMap,
 } from "../deps.ts";
 import type { S3Config } from "./client.ts";
 import type {
-  CommonPrefix,
   CopyObjectOptions,
   DeleteObjectOptions,
   DeleteObjectResponse,
@@ -25,7 +25,7 @@ import type {
 } from "./types.ts";
 import { S3Error } from "./error.ts";
 import type { Signer } from "../deps.ts";
-import { doRequest, encodeURIS3 } from "./request.ts";
+import { doRequest } from "./request.ts";
 import type { Params } from "./request.ts";
 
 export interface S3BucketConfig extends S3Config {
@@ -475,7 +475,7 @@ export class S3Bucket {
   ): Promise<PutObjectResponse> {
     const headers: Params = {};
     headers["x-amz-copy-source"] = new URL(
-      encodeURIS3(source),
+      encodeUriS3(source),
       this.#host,
     ).toString();
     if (options?.acl) headers["x-amz-acl"] = options.acl;

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -274,7 +274,7 @@ export class S3Bucket {
     if (options?.maxKeys) {
       params["max-keys"] = options.maxKeys.toString();
     }
-    if (options?.prefix) {
+    if (options?.prefix != null) {
       params["prefix"] = options.prefix;
     }
     if (options?.continuationToken) {
@@ -360,14 +360,8 @@ export class S3Bucket {
       prefix: extractContent(root, "Prefix"),
       delimiter: extractContent(root, "Delimiter"),
       maxKeys: maxkeys,
-      commonPrefixes: extractField(
-        root,
-        "CommonPrefixes",
-      )?.children.map<CommonPrefix>((prefix) => {
-        return {
-          prefix: extractContent(prefix, "Prefix"),
-        };
-      }),
+      commonPrefixes: extractMultipleFields(root, "CommonPrefixes")
+        .map((node) => ({ prefix: extractContent(node, "Prefix") })),
       encodingType: extractContent(root, "EncodingType"),
       keyCount: keycount,
       continuationToken: extractContent(root, "ContinuationToken"),
@@ -651,6 +645,10 @@ function extractRoot(doc: Document, name: string): Xml {
 
 function extractField(node: Xml, name: string): Xml | undefined {
   return node.children.find((node) => node.name === name);
+}
+
+function extractMultipleFields(node: Xml, name: string): Xml[] {
+  return node.children.filter((node) => node.name === name);
 }
 
 function extractContent(node: Xml, name: string): string | undefined {

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,8 +2,10 @@ import { AWSSignerV4 } from "../deps.ts";
 import type { CreateBucketOptions } from "./types.ts";
 import { S3Error } from "./error.ts";
 import { S3Bucket } from "./bucket.ts";
-import { doRequest, encoder } from "./request.ts";
+import { doRequest } from "./request.ts";
 import type { Params } from "./request.ts";
+
+const encoder = new TextEncoder();
 
 export interface S3Config {
   region: string;

--- a/src/client_test.ts
+++ b/src/client_test.ts
@@ -1,7 +1,8 @@
 import { assertEquals, assertThrowsAsync } from "../test_deps.ts";
 import { S3Error } from "./error.ts";
 import { S3 } from "./client.ts";
-import { encoder } from "./request.ts";
+
+const encoder = new TextEncoder();
 
 const s3 = new S3({
   accessKeyID: Deno.env.get("AWS_ACCESS_KEY_ID")!,

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,10 +1,11 @@
+import { encodeUriS3 } from "../deps.ts";
 import type { Signer } from "../deps.ts";
+
+const encoder = new TextEncoder();
 
 export interface Params {
   [key: string]: string;
 }
-
-export const encoder = new TextEncoder();
 
 interface S3RequestOptions {
   host: string;
@@ -25,7 +26,7 @@ export async function doRequest({
   headers,
   body,
 }: S3RequestOptions): Promise<Response> {
-  const url = path == "/" ? new URL(host) : new URL(encodeURIS3(path), host);
+  const url = path == "/" ? new URL(host) : new URL(encodeUriS3(path), host);
   if (params) {
     for (const key in params) {
       url.searchParams.set(key, params[key]);
@@ -44,35 +45,6 @@ export async function doRequest({
     signedRequest.headers.set("content-length", body.length.toFixed(0));
   }
   return fetch(signedRequest);
-}
-
-export function encodeURIS3(input: string): string {
-  let result = "";
-  for (const ch of input) {
-    if (
-      (ch >= "A" && ch <= "Z") ||
-      (ch >= "a" && ch <= "z") ||
-      (ch >= "0" && ch <= "9") ||
-      ch == "_" ||
-      ch == "-" ||
-      ch == "~" ||
-      ch == "."
-    ) {
-      result += ch;
-    } else if (ch == "/") {
-      result += "/";
-    } else {
-      result += stringToHex(ch);
-    }
-  }
-  return result;
-}
-
-function stringToHex(input: string) {
-  return [...encoder.encode(input)]
-    .map((s) => "%" + s.toString(16))
-    .join("")
-    .toUpperCase();
 }
 
 async function sha256Hex(data: string | Uint8Array): Promise<string> {

--- a/src/response_parsing_test.ts
+++ b/src/response_parsing_test.ts
@@ -1,0 +1,51 @@
+import { assertEquals } from "../test_deps.ts";
+import { S3Bucket } from "./bucket.ts";
+
+const bucket: S3Bucket = Object.create(S3Bucket.prototype)
+
+Deno.test("[response parsing]", async (t) => {
+  await t.step("parseListObjectResponseXml", async (t) => {
+    await t.step("commonPrefixes", () => {
+      // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html#API_ListObjectsV2_Example_8
+      const xml = `<?xml version='1.0' encoding='utf-8' ?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+          <Name>example-bucket</Name>
+          <Prefix>photos/2006/</Prefix>
+          <Marker></Marker>
+          <MaxKeys>1000</MaxKeys>
+          <Delimiter>/</Delimiter>
+          <IsTruncated>false</IsTruncated>
+          <CommonPrefixes>
+            <Prefix>photos/2006/February/</Prefix>
+          </CommonPrefixes>
+          <CommonPrefixes>
+            <Prefix>photos/2006/January/</Prefix>
+          </CommonPrefixes>
+        </ListBucketResult>`;
+
+      assertEquals(bucket["parseListObjectResponseXml"](xml).commonPrefixes, [
+        { prefix: "photos/2006/February/" },
+        { prefix: "photos/2006/January/" },
+      ]);
+    });
+
+    await t.step("commonPrefixes with entity escapes", () => {
+      const xml = `<?xml version='1.0' encoding='utf-8' ?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+          <Name>example-bucket</Name>
+          <Prefix>photos/2006/</Prefix>
+          <Marker></Marker>
+          <MaxKeys>1000</MaxKeys>
+          <Delimiter>/</Delimiter>
+          <IsTruncated>false</IsTruncated>
+          <CommonPrefixes>
+            <Prefix>photos/2006/a&amp;b/</Prefix>
+          </CommonPrefixes>
+        </ListBucketResult>`;
+
+      assertEquals(bucket["parseListObjectResponseXml"](xml).commonPrefixes, [
+        { prefix: "photos/2006/a&b/" },
+      ]);
+    });
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -243,7 +243,7 @@ export interface ListObjectsResponse {
   /**
    * All of the keys rolled up into a common prefix count as a single return when calculating the number of returns. A response can contain CommonPrefixes only if you specify a delimiter.  CommonPrefixes contains all (if there are any) keys between Prefix and the next occurrence of the string specified by a delimiter.  CommonPrefixes lists keys that act like subdirectories in the directory specified by Prefix. For example, if the prefix is notes/ and the delimiter is a slash (/) as in notes/summer/july, the common prefix is notes/summer/. All of the keys that roll up into a common prefix count as a single return when calculating the number of returns.
    */
-  commonPrefixes?: CommonPrefix[];
+  commonPrefixes: CommonPrefix[];
   /**
    * Encoding type used by Amazon S3 to encode object key names in the XML response. If you specify the encoding-type request parameter, Amazon S3 includes this element in the response, and returns encoded key name values in the following response elements:  Delimiter, Prefix, Key, and StartAfter.
    */


### PR DESCRIPTION
Fixes https://github.com/lucacasonato/deno_s3/issues/54 for prefix keys containing spaces and other idiosyncratic special characters (e.g. `~`, which was also previously failing).

This is from my fork, so it also incorporates the changes from and supersedes https://github.com/lucacasonato/deno_s3/pull/53 and fixes https://github.com/lucacasonato/deno_s3/issues/52.

`encodeUriS3` is moved into `deno_aws_sign_v4` as it doesn't make sense to have a bidirectional dependency — it's now also used for encoding the query params per AWS's spec.

If this is ever merged, you'll probably also want to change the `deps.ts` import to the deno.land/x URL for the updated `deno_aws_sign_v4`.